### PR TITLE
Using "paths" in boatsrc to define absolute paths that can be used in your spec.

### DIFF
--- a/.boatsrc
+++ b/.boatsrc
@@ -1,14 +1,17 @@
 {
   "nunjucksOptions": {
-    "tags": {
-    }
+    "tags": {}
   },
-  "jsonSchemaRefParserBundleOpts": {
-  },
+  "jsonSchemaRefParserBundleOpts": {},
   "permissionConfig": {
     "globalPrefix": false
   },
   "picomatchOptions": {
     "bash": true
+  },
+  "paths": {
+    "@oa3Mixins": "srcOA3/mixins/",
+    "@oa3Parameters/": "srcOA3/components/parameters/",
+    "@/": "./"
   }
 }

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -234,10 +234,14 @@ class Injector {
   }
 
   convertRootRefToRelative (content: string, relativePathToRoot: string) {
-    return content.replace(/(\$ref[ '"]*:[ '"]*)#\/([^ '"$]*)/g, (_: any, ref: any, rootRef: any) => {
-      const newPath = `${upath.dirname(rootRef)}/index.yml#/${upath.basename(rootRef)}`;
-      return `${ref}${relativePathToRoot}/${newPath}`;
-    });
+    return content
+      .replace(/(\$ref[ '"]*:[ '"]*)#\/([^ '"$]*)/g, (_: any, ref: any, rootRef: any) => {
+        const newPath = `${upath.dirname(rootRef)}/index.yml#/${upath.basename(rootRef)}`;
+        return `${ref}${relativePathToRoot}/${newPath}`;
+      })
+      .replace(/(\$ref[ '"]*:[ '"]*)\$\/([^ '"$]*)/g, (_: any, ref: any, rootRef: any) => {
+        return `${ref}${relativePathToRoot}/${rootRef}`;
+      });
   }
 }
 

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -244,6 +244,7 @@ class Template {
   /**
    * Sets up the tpl engine for the current file being rendered
    */
+  // eslint-disable-next-line max-lines-per-function
   async nunjucksSetup () {
     const env = nunjucks.configure(this.boatsrc.nunjucksOptions);
 
@@ -258,6 +259,7 @@ class Template {
       });
     }
     env.addGlobal('boatsConfig', this.boatsrc);
+    env.addGlobal('baseDir', upath.dirname(this.inputFile));
     env.addGlobal('mixinNumber', this.mixinNumber);
     env.addGlobal('mixinObject', this.mixinObject);
     env.addGlobal('indentNumber', this.indentNumber);

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -23,6 +23,7 @@ import uniqueOpId from '@/nunjucksHelpers/uniqueOpId';
 import optionalProps from './nunjucksHelpers/optionalProps';
 import pickProps from './nunjucksHelpers/pickProps';
 import { BoatsRC } from '@/interfaces/BoatsRc';
+import { pathInjector } from './pathInjector';
 
 // No types found for walker
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -259,7 +260,7 @@ class Template {
       });
     }
     env.addGlobal('boatsConfig', this.boatsrc);
-    env.addGlobal('baseDir', upath.dirname(this.inputFile));
+    env.addGlobal('pathInjector', new pathInjector(this.boatsrc.paths));
     env.addGlobal('mixinNumber', this.mixinNumber);
     env.addGlobal('mixinObject', this.mixinObject);
     env.addGlobal('indentNumber', this.indentNumber);

--- a/src/__tests__/buildFilesData/builtOA3.json
+++ b/src/__tests__/buildFilesData/builtOA3.json
@@ -28,43 +28,78 @@
   "paths": {
     "/relative": {
       "get": {
-         "tags": [
-            "Relative"
-         ],
-         "summary": "Example Relative Mixin Path",
-         "description": "Use a mixin which contains a relative path",
-         "operationId": "relativeGet",
-         "responses": {
-            "200": {
-               "description": "Successful fetch",
-               "content": {
-                  "application/json": {
-                     "schema": {
-                        "type": "object",
-                        "properties": {
-                           "included": {
-                              "type": "object",
-                              "properties": {
-                                 "one": {
-                                    "type": "string"
-                                 }
-                              }
-                           },
-                           "data": {
-                              "type": "array",
-                              "items": {
-                                 "$ref": "#/components/schemas/Weathers"
-                              }
-                           }
+        "tags": [
+          "Relative"
+        ],
+        "summary": "Example Relative Mixin Path",
+        "description": "Use a mixin which contains a relative path",
+        "operationId": "relativeGet",
+        "responses": {
+          "200": {
+            "description": "Successful fetch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "included": {
+                      "type": "object",
+                      "properties": {
+                        "one": {
+                          "type": "string"
                         }
-                     }
+                      }
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Weathers"
+                      }
+                    }
                   }
-               }
-            },
-            "404": {
-               "description": "Temp not found"
+                }
+              }
             }
-         }
+          },
+          "404": {
+            "description": "Temp not found"
+          }
+        }
+      }
+    },
+    "/absolute": {
+      "get": {
+        "tags": [
+          "Absolute"
+        ],
+        "summary": "Example Absolute Mixin Path",
+        "description": "Use a schema which contains absolute paths to specified in the boatsrc file",
+        "operationId": "absoluteGet",
+        "responses": {
+          "200": {
+            "description": "Successful fetch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "included": {
+                      "type": "object",
+                      "properties": {
+                        "absolute": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Temp not found"
+          }
+        }
       }
     },
     "/weather": {
@@ -162,6 +197,11 @@
         "summary": "weather data",
         "description": "Create a new weather record.",
         "operationId": "weatherIdIdPut",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PathId"
+          }
+        ],
         "requestBody": {
           "description": "Optional description in *Markdown*",
           "required": true,

--- a/src/__tests__/buildFilesData/builtOA3_exclude.json
+++ b/src/__tests__/buildFilesData/builtOA3_exclude.json
@@ -28,43 +28,78 @@
   "paths": {
     "/relative": {
       "get": {
-         "tags": [
-            "Relative"
-         ],
-         "summary": "Example Relative Mixin Path",
-         "description": "Use a mixin which contains a relative path",
-         "operationId": "relativeGet",
-         "responses": {
-            "200": {
-               "description": "Successful fetch",
-               "content": {
-                  "application/json": {
-                     "schema": {
-                        "type": "object",
-                        "properties": {
-                           "included": {
-                              "type": "object",
-                              "properties": {
-                                 "one": {
-                                    "type": "string"
-                                 }
-                              }
-                           },
-                           "data": {
-                              "type": "array",
-                              "items": {
-                                 "$ref": "#/components/schemas/Weathers"
-                              }
-                           }
+        "tags": [
+          "Relative"
+        ],
+        "summary": "Example Relative Mixin Path",
+        "description": "Use a mixin which contains a relative path",
+        "operationId": "relativeGet",
+        "responses": {
+          "200": {
+            "description": "Successful fetch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "included": {
+                      "type": "object",
+                      "properties": {
+                        "one": {
+                          "type": "string"
                         }
-                     }
+                      }
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Weathers"
+                      }
+                    }
                   }
-               }
-            },
-            "404": {
-               "description": "Temp not found"
+                }
+              }
             }
-         }
+          },
+          "404": {
+            "description": "Temp not found"
+          }
+        }
+      }
+    },
+    "/absolute": {
+      "get": {
+        "tags": [
+          "Absolute"
+        ],
+        "summary": "Example Absolute Mixin Path",
+        "description": "Use a schema which contains absolute paths to specified in the boatsrc file",
+        "operationId": "absoluteGet",
+        "responses": {
+          "200": {
+            "description": "Successful fetch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "included": {
+                      "type": "object",
+                      "properties": {
+                        "absolute": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Temp not found"
+          }
+        }
       }
     },
     "/weather": {
@@ -162,6 +197,11 @@
         "summary": "weather data",
         "description": "Create a new weather record.",
         "operationId": "weatherIdIdPut",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PathId"
+          }
+        ],
         "requestBody": {
           "description": "Optional description in *Markdown*",
           "required": true,

--- a/src/interfaces/BoatsRc.ts
+++ b/src/interfaces/BoatsRc.ts
@@ -12,6 +12,10 @@ export interface MethodAlias {
   delete?: string;
 }
 
+export interface Paths {
+    [key: string]: string;
+  }
+
 export interface BoatsRC {
   nunjucksOptions?: {
     tags?: {
@@ -36,4 +40,5 @@ export interface BoatsRC {
   };
   picomatchOptions?: any;
   fancyPluralization?: boolean;
+  paths?: Paths;
 }

--- a/src/nunjucksHelpers/mixin.ts
+++ b/src/nunjucksHelpers/mixin.ts
@@ -7,7 +7,16 @@ const mixinDirectoryKey = 'mixinDirectory';
 export default function (): string {
   const tplGlobals = this.env.globals;
   // eslint-disable-next-line prefer-rest-params
-  const renderPath = upath.join(upath.dirname(tplGlobals.currentFilePointer), arguments[0]);
+  let argumentPath = arguments[0]
+
+  if (argumentPath.match(/\$/g)) {
+    const diff = upath.relative(upath.dirname(tplGlobals.currentFilePointer), tplGlobals.baseDir);
+
+    argumentPath = upath.normalize(argumentPath.replace('$', diff));
+  }
+
+  const renderPath = upath.join(upath.dirname(tplGlobals.currentFilePointer), argumentPath);
+
   if (!fs.pathExistsSync(renderPath)) {
     throw new Error('Path not found when trying to render mixin: ' + renderPath);
   }

--- a/src/pathInjector.ts
+++ b/src/pathInjector.ts
@@ -1,0 +1,67 @@
+import * as upath from 'upath';
+import { Paths } from './interfaces/BoatsRc';
+
+export class pathInjector {
+  keyPatterns: string[];
+  public injectMixin: (target: string) => [string, boolean];
+  public injectRefs: (target: string, relativeRoot: string) => string;
+  mixinExpressions: RegExp[];
+  refExpressions: RegExp[];
+
+  constructor(private paths: Paths, private pathModifier?: string) {
+    this.paths = paths;
+    this.pathModifier = pathModifier || '';
+
+    if (paths) {
+      // If we have paths, setup a working strategy and assign it, trim trailing slashes to avoid stripping them out later
+      this.keyPatterns = Object.keys(paths);
+      this.mixinExpressions = this.keyPatterns.map((str) => str.replace(/\/$/, '')).map((str) => new RegExp(str, 'g'));
+      this.refExpressions = this.keyPatterns
+        .map((str) => str.replace(/\/$/, ''))
+        .map((str) => new RegExp(`(\\$ref[ '"]*:[ '"]*)(${str})`, 'gs'));
+
+      this.injectMixin = this.doInject;
+      this.injectRefs = this.doInjectRefs;
+    } else {
+      // Inject the null strategy
+      this.injectMixin = this.skip;
+      this.injectRefs = (str, _) => str;
+    }
+  }
+
+  private skip(target: string): [string, boolean] {
+    return [target, false];
+  }
+
+  private doInject(target: string): [string, boolean] {
+    for (let i = 0; i < this.mixinExpressions.length; i++) {
+      const keyPattern = this.mixinExpressions[i];
+
+      if (keyPattern.test(target)) {
+        const value = upath.join(this.pathModifier, this.paths[this.keyPatterns[i]]);
+
+        return [upath.normalize(target.replace(keyPattern, value)), true];
+      }
+    }
+
+    return [target, false];
+  }
+
+  private doInjectRefs(target: string, relativeRoot: string): string {
+    for (let i = 0; i < this.refExpressions.length; i++) {
+      const keyPattern = this.refExpressions[i];
+
+      if (keyPattern.test(target)) {
+        // First remove the relative path from the .boatsrc to the index file,
+        // as the templating has already happened
+        // files are no longer where they were, and have all moved to locations relative to the index file
+        const value = upath.join(relativeRoot,
+          upath.relative(this.pathModifier, this.paths[this.keyPatterns[i]]));
+
+        return target.replace(keyPattern, `$1${value}`).replace('//', '/');
+      }
+    }
+
+    return target;
+  }
+}

--- a/srcOA2/paths/v1/weather/latest/get.yml.njk
+++ b/srcOA2/paths/v1/weather/latest/get.yml.njk
@@ -9,6 +9,6 @@ responses:
   '200':
     description: Successful fetch
     schema:
-      $ref: ../../../../definitions/weather/models.yml.njk
+      $ref: @/srcOA2/definitions/weather/models.yml.njk
   '404':
     description: Temp not found

--- a/srcOA3/mixins/response/absoluteTest.yml.njk
+++ b/srcOA3/mixins/response/absoluteTest.yml.njk
@@ -1,0 +1,6 @@
+application/json:
+  schema:
+    type: object
+    properties:
+      included:
+        $ref: {{ mixinDirectory }}/referredFromAbsolute.yml.njk

--- a/srcOA3/mixins/response/referredFromAbsolute.yml.njk
+++ b/srcOA3/mixins/response/referredFromAbsolute.yml.njk
@@ -1,0 +1,4 @@
+type: object
+properties:
+  absolute:
+    type: string

--- a/srcOA3/paths/absolute/get.yml.njk
+++ b/srcOA3/paths/absolute/get.yml.njk
@@ -1,0 +1,11 @@
+tags:
+  - {{ autoTag() }}
+summary: Example Absolute Mixin Path
+description: Use a schema which contains absolute paths to specified in the boatsrc file
+operationId: {{ uniqueOpId() }}
+responses:
+  '200':
+    description: Successful fetch
+    content: {{ mixin("@oa3Mixins/response/absoluteTest.yml.njk", "../../components/schemas/weather/models.yml.njk") }}
+  '404':
+    description: Temp not found

--- a/srcOA3/paths/weather/id/{id}/get.yml.njk
+++ b/srcOA3/paths/weather/id/{id}/get.yml.njk
@@ -4,10 +4,10 @@ summary: weather data
 description: Get the latest temperatures
 operationId: {{ uniqueOpId() }}
 parameters:
-  - $ref: $/components/parameters/pathId.yml.njk
+  - $ref: @oa3Parameters/pathId.yml.njk
 responses:
   '200':
     description: Successful fetch
-    content: {{ mixin("$/mixins/response/json.yml.njk", "../../../../components/schemas/weather/model.yml.njk") }}
+    content: {{ mixin("@oa3Mixins/response/json.yml.njk", "../../../../components/schemas/weather/model.yml.njk") }}
   '404':
     description: Temp not found

--- a/srcOA3/paths/weather/id/{id}/get.yml.njk
+++ b/srcOA3/paths/weather/id/{id}/get.yml.njk
@@ -4,10 +4,10 @@ summary: weather data
 description: Get the latest temperatures
 operationId: {{ uniqueOpId() }}
 parameters:
-  - $ref: ../../../../components/parameters/pathId.yml.njk
+  - $ref: $/components/parameters/pathId.yml.njk
 responses:
   '200':
     description: Successful fetch
-    content: {{ mixin("../../../../mixins/response/json.yml.njk", "../../../../components/schemas/weather/model.yml.njk") }}
+    content: {{ mixin("$/mixins/response/json.yml.njk", "../../../../components/schemas/weather/model.yml.njk") }}
   '404':
     description: Temp not found

--- a/srcOA3/paths/weather/id/{id}/put.yml.njk
+++ b/srcOA3/paths/weather/id/{id}/put.yml.njk
@@ -3,6 +3,8 @@ tags:
 summary: weather data
 description: Create a new weather record.
 operationId: {{ uniqueOpId() }}
+parameters:
+  - $ref: @oa3Parameters/pathId.yml.njk
 requestBody:
   description: Optional description in *Markdown*
   required: true


### PR DESCRIPTION
A proof of concept demonstrating using a simple shorthand (in this case `$`) to refer to the root of the spec repository.

The intention is to improve the developer experience by removing the need to manage relative paths where content can move independently (e.g. between paths, schemas and mixins).

If the concept is okay, can improve the testing suite to improve coverage and make tests more explicit.