### PR TITLE
create default boatsrc when none is found closes #31

### DIFF
--- a/src/GetCheckCorrectBoatsRc.ts
+++ b/src/GetCheckCorrectBoatsRc.ts
@@ -1,9 +1,10 @@
+import { MethodAliasPosition } from '@/enums/MethodAliasPosition';
 import { StringStyle } from '@/enums/StringStyle';
-import { BoatsRC } from './interfaces/BoatsRc';
+import deepmerge from 'deepmerge';
 import fs from 'fs-extra';
 import upath from 'upath';
-import { MethodAliasPosition } from '@/enums/MethodAliasPosition';
-import deepmerge from 'deepmerge';
+import { createBoatsrcIfNotExists } from './init';
+import { BoatsRC } from './interfaces/BoatsRc';
 
 class GetCheckCorrectBoatsRc {
   boatsRc: BoatsRC;
@@ -31,6 +32,8 @@ class GetCheckCorrectBoatsRc {
    */
   getBoatsConfig() {
     const boatsrc = upath.join(process.cwd(), '.boatsrc');
+    createBoatsrcIfNotExists();
+
     try {
       const boatsRcJson: BoatsRC = fs.readJsonSync(boatsrc);
       const json = deepmerge(this.defaultRc, boatsRcJson);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import 'colors';
 import GetCheckCorrectBoatsRc from '@/GetCheckCorrectBoatsRc';
 import { BoatsRC } from '@/interfaces/BoatsRc';
 import Snippets from '@/Snippets';
-import { init, createBoatsrcIfNotExists } from './init';
+import { init } from './init';
 
 const dotenvFilePath = upath.join(process.cwd(), '.env');
 const boatsRc: BoatsRC = GetCheckCorrectBoatsRc.getBoatsConfig();
@@ -46,7 +46,6 @@ const parseCli = async () => {
     // Return init function
     await init();
   } else {
-    createBoatsrcIfNotExists();
     // parse the directory then validate and bundle with swagger-parser
     const returnFile = await Template.directoryParse(
       program.input,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import 'colors';
 import GetCheckCorrectBoatsRc from '@/GetCheckCorrectBoatsRc';
 import { BoatsRC } from '@/interfaces/BoatsRc';
 import Snippets from '@/Snippets';
+import { init, createBoatsrcIfNotExists } from './init';
 
 const dotenvFilePath = upath.join(process.cwd(), '.env');
 const boatsRc: BoatsRC = GetCheckCorrectBoatsRc.getBoatsConfig();
@@ -38,13 +39,14 @@ const parseCli = async () => {
   } else if (program.convert_to_yml) {
     // Convert files to yaml
     convertToNunjucksOrYaml(program.convert_to_yml, 'yml');
-  } else if(program.injectSnippet) {
+  } else if (program.injectSnippet) {
     // Snippets
-    new Snippets(program)
+    new Snippets(program);
   } else if (program.init) {
     // Return init function
-    require('./init');
+    await init();
   } else {
+    createBoatsrcIfNotExists();
     // parse the directory then validate and bundle with swagger-parser
     const returnFile = await Template.directoryParse(
       program.input,

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,9 +1,9 @@
-import inquirer from 'inquirer';
-import fs from 'fs-extra';
-import upath from 'upath';
 import { BoatsRC } from '@/interfaces/BoatsRc';
-import boatsPackageJson from '../package.json';
 import { spawn } from 'child_process';
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import upath from 'upath';
+import boatsPackageJson from '../package.json';
 
 const pwd = upath.toUnix(process.cwd());
 const srcPath = upath.join(pwd, '/src');
@@ -11,82 +11,144 @@ const srcAlreadyExists = fs.pathExistsSync(srcPath);
 const buildPath = upath.join(pwd, '/build');
 const buildAlreadyExists = fs.pathExistsSync(srcPath);
 
-const npmInstall = () => new Promise<number>((resolve, reject) => {
-  spawn('npm', ['install'], {
-    stdio: 'inherit',
-    cwd: pwd
-  })
-    .on('close', (code) => {
+const npmInstall = (): Promise<number> =>
+  new Promise<number>((resolve, reject) => {
+    spawn('npm', ['install'], {
+      stdio: 'inherit',
+      cwd: pwd,
+    }).on('close', (code) => {
       if (code !== 0) {
         return reject(Error('npm install command was unsuccessful'));
       }
 
       resolve(0);
     });
-});
-
-if (srcAlreadyExists || buildAlreadyExists) {
-  throw new Error(
-    'Process stopped as ' +
-    srcAlreadyExists +
-    ' &/or' +
-    buildPath +
-    'already found. Installation cannot run with these folders existing.'
-  );
-}
+  });
 
 const localPkgJsonPath = upath.join(pwd, 'package.json');
-if (!fs.pathExistsSync(localPkgJsonPath)) {
-  throw new Error('Error: No package.json file found. Please add a package.json file to continue');
-}
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const localPkgJson = require(localPkgJsonPath);
-
-localPkgJson.dependencies = {
-  ...(localPkgJson.dependencies || {}),
-  'boats': `^${boatsPackageJson.version}`
+const getQuestions = (localPkgJson: Record<string, any>): inquirer.ListQuestionOptions[] => {
+  return [
+    {
+      type: 'input',
+      name: 'name',
+      message: 'Enter the name of the api file, press enter to use the current package.json name attribute:',
+      default: localPkgJson.name,
+      validate: function (value: any) {
+        return (typeof value === 'string' && value.length > 1) || 'Please enter a name longer than 1 character';
+      },
+    },
+    {
+      type: 'confirm',
+      name: 'updateName',
+      message:
+        'The current package.json name does not match the api name entered. Would you the package.json name to be updated too?',
+      when: function (answers: any) {
+        return answers.name !== localPkgJson.name;
+      },
+    },
+    {
+      type: 'list',
+      name: 'oaType',
+      choices: ['Swagger 2.0', 'OpenAPI 3.0.0', 'AsyncAPI 2.0.0'],
+    },
+    {
+      type: 'confirm',
+      name: 'installConfirm',
+      message:
+        'Press Y and enter to install. This will make a copy of the template files to ./src, an output directory ./build and a config file ./.boatsrc',
+      default: false,
+    },
+  ];
 };
 
-const questions = [
-  {
-    type: 'input',
-    name: 'name',
-    message: 'Enter the name of the api file, press enter to use the current package.json name attribute:',
-    default: localPkgJson.name,
-    validate: function(value: any) {
-      return (typeof value === 'string' && value.length > 1) || 'Please enter a name longer than 1 character';
-    }
-  },
-  {
-    type: 'confirm',
-    name: 'updateName',
-    message:
-      'The current package.json name does not match the api name entered. Would you the package.json name to be updated too?',
-    when: function(answers: any) {
-      return answers.name !== localPkgJson.name;
-    }
-  },
-  {
-    type: 'list',
-    name: 'oaType',
-    choices: [
-      'Swagger 2.0',
-      'OpenAPI 3.0.0',
-      'AsyncAPI 2.0.0'
-    ]
-  },
-  {
-    type: 'confirm',
-    name: 'installConfirm',
-    message:
-      'Press Y and enter to install. This will make a copy of the template files to ./src, an output directory ./build and a config file ./.boatsrc',
-    default: false
+const validatePreInit = (): Record<string, any> => {
+  if (srcAlreadyExists || buildAlreadyExists) {
+    throw new Error(
+      'Process stopped as ' +
+        srcAlreadyExists +
+        ' &/or' +
+        buildPath +
+        'already found. Installation cannot run with these folders existing.'
+    );
   }
-];
 
-(async () => {
+  if (!fs.pathExistsSync(localPkgJsonPath)) {
+    throw new Error('Error: No package.json file found. Please add a package.json file to continue');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const localPkgJson = require(localPkgJsonPath);
+
+  localPkgJson.dependencies = {
+    ...(localPkgJson.dependencies || {}),
+    boats: `^${boatsPackageJson.version}`,
+  };
+
+  return localPkgJson;
+};
+
+export const createBoatsrcIfNotExists = (force = false): void => {
+  const boatsrcDefault: BoatsRC = {
+    nunjucksOptions: {
+      tags: {},
+    },
+    jsonSchemaRefParserBundleOpts: {},
+    picomatchOptions: {
+      bash: true,
+    },
+    permissionConfig: {
+      globalPrefix: true,
+    },
+  };
+  if (force || !fs.existsSync(upath.join(pwd, '/.boatsrc'))) {
+    fs.writeFileSync(upath.join(pwd, '/.boatsrc'), JSON.stringify(boatsrcDefault, null, 4));
+  }
+};
+
+const copyBoilerplate = (answers: Record<string, string>) => {
+  if (answers.oaType === 'Swagger 2.0') {
+    fs.copySync(upath.join(__dirname, '../../srcOA2'), srcPath);
+  } else if (answers.oaType === 'OpenAPI 3.0.0') {
+    fs.copySync(upath.join(__dirname, '../../srcOA3'), srcPath);
+  } else if (answers.oaType === 'AsyncAPI 2.0.0') {
+    fs.copySync(upath.join(__dirname, '../../srcASYNC2'), srcPath);
+  }
+  console.log('Completed: Installed boats skeleton files to ' + srcPath);
+  fs.ensureDirSync(buildPath);
+
+  console.log('Completed: Created a build output directory');
+};
+
+const updatePackageJson = (answers: Record<string, string>) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const localPkgJson = require(localPkgJsonPath);
+
+  const name = answers.name;
+  if (answers.updateName) {
+    localPkgJson.name = name;
+  }
+  localPkgJson['scripts']['build:json'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.json';
+  localPkgJson['scripts']['build:yaml'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.yml';
+  localPkgJson['scripts']['build'] = 'npm run build:json && npm run build:yaml';
+
+  // ensure the licence and private field is correct in the package.json
+  // we assume private by default and let the user correct otherwise.
+  delete localPkgJson.license;
+  localPkgJson.private = true;
+
+  // Write the new json object to file
+  fs.writeFileSync(localPkgJsonPath, JSON.stringify(localPkgJson, null, 2));
+  console.log('Completed: BOATS build scripts added to your package.json');
+  if (answers.updateName) {
+    return console.log('Completed: Package json name attr updated');
+  }
+};
+
+export const init = async (): Promise<void> => {
   try {
+    const localPkgJson = validatePreInit();
+    const questions = getQuestions(localPkgJson);
     const answers = await inquirer.prompt(questions);
 
     if (!answers.installConfirm) {
@@ -94,49 +156,12 @@ const questions = [
     }
 
     // write boatsrc to disc
-    const boatsrcDefault: BoatsRC = {
-      nunjucksOptions: {
-        tags: {}
-      },
-      jsonSchemaRefParserBundleOpts: {},
-      picomatchOptions: {
-        bash: true
-      },
-      permissionConfig: {
-        globalPrefix: true
-      }
-    };
-    fs.writeFileSync(upath.join(pwd, '/.boatsrc'), JSON.stringify(boatsrcDefault, null, 4));
+    createBoatsrcIfNotExists();
     console.log('Completed: Injected a .boatsrc file');
-    if (answers.oaType === 'Swagger 2.0') {
-      fs.copySync(upath.join(__dirname, '../../srcOA2'), srcPath);
-    } else if (answers.oaType === 'OpenAPI 3.0.0') {
-      fs.copySync(upath.join(__dirname, '../../srcOA3'), srcPath);
-    } else if (answers.oaType === 'AsyncAPI 2.0.0') {
-      fs.copySync(upath.join(__dirname, '../../srcASYNC2'), srcPath);
-    }
-    console.log('Completed: Installed boats skeleton files to ' + srcPath);
-    fs.ensureDirSync(buildPath);
-    console.log('Completed: Created a build output directory');
-    const name = answers.name;
-    if (answers.updateName) {
-      localPkgJson.name = name;
-    }
-    localPkgJson['scripts']['build:json'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.json';
-    localPkgJson['scripts']['build:yaml'] = 'boats -i ./src/index.yml.njk -o ./build/${npm_package_name}.yml';
-    localPkgJson['scripts']['build'] = 'npm run build:json && npm run build:yaml';
 
-    // ensure the licence and private field is correct in the package.json
-    // we assume private by default and let the user correct otherwise.
-    delete localPkgJson.license;
-    localPkgJson.private = true;
+    copyBoilerplate(answers);
 
-    // Write the new json object to file
-    fs.writeFileSync(localPkgJsonPath, JSON.stringify(localPkgJson, null, 2));
-    console.log('Completed: BOATS build scripts added to your package.json');
-    if (answers.updateName) {
-      return console.log('Completed: Package json name attr updated');
-    }
+    updatePackageJson(answers);
 
     await npmInstall();
     console.log('Completed: Installed dependencies');
@@ -144,4 +169,4 @@ const questions = [
     console.log('Aborting installation:');
     console.error(e);
   }
-})();
+};


### PR DESCRIPTION
- refactor the init file to also export the default boatsrc create method.
- call create boatsfile (if one is not found)

- previsouly had maybe 20 files worth of `npm run format` but I'll leave that to you.