### PR TITLE
feat: Allow loading of external helpers in TypeScript.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -651,6 +651,7 @@ url: <$ host $>
 > !Tip: These variables will override any variables injected into the tpl engine from the `process.env`
 
 ## Changelog
+- 2021/10/05 2.25.0: allow loading of helper files in TypeScript using ts-node
 - 2021/09/19 2.24.0: npm version check updated to use npm api instead of github json url
 - 2021/09/19 2.23.0: npm version check updated
 - 2021/09/13 2.22.0: (TEMP) The npm / github version check is removed to bypass github stalling issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1902,9 +1902,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
     },
     "cli-width": {
       "version": "3.0.0",
@@ -5226,9 +5226,9 @@
       }
     },
     "npm-tool-version-check": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/npm-tool-version-check/-/npm-tool-version-check-1.1.4.tgz",
-      "integrity": "sha512-ynmLsD37Ib7hAUmM031q2za5vfwoXY8Ww7T42JkF5BDf5FEceXuDJ3oJlHNPbWTeH2qYouY4gZMw+BtRoyhokQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-tool-version-check/-/npm-tool-version-check-1.2.0.tgz",
+      "integrity": "sha512-ppM17yOZbh0z3xzk2YR1y2VtJvXGftG60+t5BZEH41v6WWyaeztM/DC4kBZw8UGtXNl4sTB+UcPPzoEMcfbYyA==",
       "requires": {
         "colors": "^1.4.0",
         "inquirer": "^8.1.5",
@@ -5267,9 +5267,9 @@
           }
         },
         "rxjs": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-          "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.1.tgz",
+          "integrity": "sha512-vNenx7gqjPyeKpRnM6S5Ksm/oFTRijWWzYlRON04KaehZ3YjDwEmVjGUGo0TKWVjeNXOujVRlh0K1drUbcdPkw==",
           "requires": {
             "tslib": "~2.1.0"
           },

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -248,7 +248,6 @@ class Template {
   // eslint-disable-next-line max-lines-per-function
   nunjucksSetup () {
     const env = nunjucks.configure(this.boatsrc.nunjucksOptions);
-
     const processEnvVars = cloneObject(process.env);
     for (const key in processEnvVars) {
       env.addGlobal(key, processEnvVars[key]);
@@ -288,8 +287,18 @@ class Template {
     // already injected, which could be good thing if you know what you are doing.
     for (let i = 0; i < this.helpFunctionPaths.length; ++i) {
       const filePath = this.helpFunctionPaths[i];
+
+      if (filePath.endsWith('.ts')) {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('ts-node').register();
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       let helper = require(filePath);
+      if (typeof helper !== 'function' && typeof helper.default === 'function') {
+        helper = helper.default;
+      }
+
       const helperType = helper(nunjucks);
       if (typeof helperType === 'function') {
         helper = helperType;

--- a/src/__tests__/testHelpers/exampleJsHelper.js
+++ b/src/__tests__/testHelpers/exampleJsHelper.js
@@ -1,0 +1,1 @@
+module.exports = () => function exampleJsHelper() {};

--- a/src/__tests__/testHelpers/exampleTsHelper.ts
+++ b/src/__tests__/testHelpers/exampleTsHelper.ts
@@ -1,0 +1,1 @@
+export default () => function exampleTsHelper() {};

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -17,7 +17,7 @@ export default (args: any[]): any => {
     )
     .option(
       '-f, --functions [filepath]',
-      'Array of helper function relative paths, eg "-f ./helperOne.js -f ./helperTwo"',
+      'Array of helper function relative paths, eg "-f ./helperOne.js -f ./helperTwo -f ./helperThree.ts"',
       helperFunctions,
       []
     )


### PR DESCRIPTION
Allows loading proper TypeScript helper files instead of the usual JavaScript ones.
Also added a bit more unit tests to test one of the `Template.ts` functions.

**Example usage:**
```bash
$ boats -f ./nunjucksHelpers/myTypeScriptHelper.ts -i ./src/index.yml -o ./build/api.yml
```

Uses `ts-node` which should be installed as a peer dependency in this case.